### PR TITLE
Removed inline styles

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,5 +2,5 @@ Header always set Strict-Transport-Security "max-age=63072000; includeSubdomains
 Header always append X-Frame-Options DENY
 Header set X-Content-Type-Options nosniff
 Header set X-XSS-Protection "1; mode=block"
-Header set Content-Security-Policy "default-src 'none'; font-src 'self' https://fonts.gstatic.com; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/"
+Header set Content-Security-Policy "default-src 'none'; font-src 'self' https://fonts.gstatic.com; img-src 'self'; script-src 'self' ; style-src 'self' https://fonts.googleapis.com/"
 Header always set Referrer-Policy "same-origin"

--- a/_config.yml
+++ b/_config.yml
@@ -22,3 +22,8 @@ github:
 plugins:
   - jekyll-sitemap
   - jekyll-redirect-from
+
+# Custom headers
+webrick:
+  headers:
+    Content-Security-Policy: default-src 'none'; font-src 'self' https://fonts.gstatic.com; img-src 'self'; script-src 'self' ; style-src 'self' https://fonts.googleapis.com/;

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -36,7 +36,7 @@ Example:
 		{% for item in site.data.navigation %}
 			{% if item.link == "/cases/" %}
 		    	<li class="menu-item has-children">
-		    		<a href="/cases/" {% if page.url == item.link %}style="color: black;"{% endif %}> 
+		    		<a href="/cases/" {% if page.url == item.link %}class="black_url"{% endif %}> 
 						Cases <span class="dropdown-icon"></span>
 					</a>
    					<ul class="sub-menu">
@@ -44,7 +44,7 @@ Example:
 				    	{% for p in pages %}
 		    				{% if p.url contains "/cases/" and p.url != "/cases/" and p.layout != "redirect" %}
 		    					<li class="menu-item">
-			    					<a href="{{ p.url }}" {% if page.url == p.url %}style="color: black;"{% endif %}>
+			    					<a href="{{ p.url }}" {% if page.url == p.url %}class="black_url"{% endif %}>
 			    						{{ p.divd }}<br>
 			    						{{ p.short }}
 			    					</a>
@@ -55,14 +55,14 @@ Example:
 		    	</li>
 			{% elsif item.link == "/blog/" %}
 		    	<li class="menu-item has-children">
-		    		<a href="/blog/" {% if page.url == item.link %}style="color: black;"{% endif %}> 
+		    		<a href="/blog/" {% if page.url == item.link %}class="black_url"{% endif %}> 
 						Blog <span class="dropdown-icon"></span>
 					</a>
    					<ul class="sub-menu">
 						{% for post in site.posts %}
 							{% if forloop.index <= 5 %}
 							    <li class="menu-item">
-							        <a href="{{ post.url | prepend: site.baseurl }}" {% if page.url == post.url %}style="color: black;"{% endif %}> {{ post.date | date: "%Y-%m-%d" }} : {{ post.title | slice: 0, 30 }}...</a>
+							        <a href="{{ post.url | prepend: site.baseurl }}" {% if page.url == post.url %}class="black_url"{% endif %}> {{ post.date | date: "%Y-%m-%d" }} : {{ post.title | slice: 0, 30 }}...</a>
 							    </li>
 							{% endif %}
 						{% endfor %}
@@ -70,7 +70,7 @@ Example:
 		    	</li>
 			{% elsif item.link == "/faq/" %}
 		    	<li class="menu-item has-children">
-		    		<a href="/faq/" {% if page.url == item.link %}style="color: black;"{% endif %}> 
+		    		<a href="/faq/" {% if page.url == item.link %}class="black_url"{% endif %}> 
 						FAQ <span class="dropdown-icon"></span>
 					</a>
    					<ul class="sub-menu">
@@ -78,7 +78,7 @@ Example:
 				    	{% for p in pages %}
 		    				{% if p.url contains "/faq/" and p.url != "/faq/" %}
 		    					<li class="menu-item">
-			    					<a href="{{ p.url }}" {% if page.url == p.url %}style="color: black;"{% endif %}>
+			    					<a href="{{ p.url }}" {% if page.url == p.url %}class="black_url"{% endif %}>
 			    						{{ p.title | slice: 0, 40 }}...
 			    					</a>
 			    				</li>
@@ -88,7 +88,7 @@ Example:
 		    	</li>
 			{% else %}
 				<li class="menu-item">
-					<a href="{{ item.link }}" {% if page.url == item.link %}style="color: black;"{% endif %}>
+					<a href="{{ item.link }}" {% if page.url == item.link %}class="black_url"{% endif %}>
 						{{ item.name }}
 					</a>
 				</li>

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -87,6 +87,12 @@ $menu-link-padding: 1em;
 
 // Zero-down the margin and the padding for menu-lists if not done
 // in the base reset
+
+.black_url {
+  color: black !important;
+}
+
+
 .menu,
 .sub-menu {
   margin: 0;


### PR DESCRIPTION
WOrk of @Lennaert89 

Removed all occurences of "style=" inside html and applied classes to these elements with the styling inside CSS files. This means the unsafe-inline directive from the CSP headers can be removed.

Added the CSP headers to _config.yml so development enviroments match the rules of production.

Updated the headers inside the .htaccess file.

Known issue: Chrome applies css and (inline)JS to .xml files (and robots.txt?), so the XML feed looks ugly in chrome and gives an error inside developer console. This works fine on other browsers. Seems same issue as:
https://github.com/mozilla/django-csp/issues/147