### PR TITLE
Menu not working on mobile

### DIFF
--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -29,7 +29,7 @@ Example:
 {% endcomment %}
 
 <nav class="nav nav--cen">
-	<a href="javascript:void(0);" class="icon" onclick="menuFunction()">
+	<a class="icon" onclick="menuFunction()">
 		<i class="fa fa-bars"></i> Menu
 	  </a>
 	<ul class="menu" id="nav_menu">

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -52,4 +52,5 @@ function menuFunction() {
 	} else {
 	  x.className = "menu";
 	}
+	event.preventDefault()
   }


### PR DESCRIPTION
Menu relied on a piece of inline JS which was blocked by proper CSP headers. This should repair that.